### PR TITLE
requiring with npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/index');

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name":         "ODM",
   "description":  "ODM mongodb library for node.js",
   "keywords":     ["mongodb", "database", "mongo", "model"],
-  "contributors": [
-    "Paulo Lopes"
-  ],
   "version":      "0.0.1",
+  "author":       "Paulo Lopes",
+  "contributors": [
+    "Tom Wieland"
+  ],
   "engines":      {
     "node":       ">=0.4.12"
   },
   "dependencies": {
     "mongodb":   ">=0.9.7"
   },
-  "main" : "./lib/index.js"
+  "main" : "index"
 }


### PR DESCRIPTION
It's easier to require a package with npm if it directly exports the library.
